### PR TITLE
feat: improved HTTP request error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbta-rs"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 authors = ["Robert Yin <bobertoyin@gmail.com>"]
 description = "Simple Rust client for interacting with the MBTA V3 API."
@@ -19,3 +19,4 @@ chrono = "0.4.19"
 ureq = { version = "2.4.0", features = ["json"] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
+thiserror = "1.0.31"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This project provides a simple synchronous client and data models to easily cons
 > Why provide a synchronous client rather than an asynchronous one?
 
 1. I didn't want this crate to be tied down to a specific `async` runtime
-2. I wanted to use the `ureq` crate for its simple API and small size, but it only provides a synchronous API
+2. I wanted to use the `ureq` crate for its simple API and small size, and it only provides a synchronous client
 
 > Why not auto-generate a client, given that the OpenAPI/Swagger client code-generators exists?
 
@@ -48,6 +48,28 @@ mbta-rs = "*"
 # if you need to manipulate/further inspect certain fields
 chrono = "*"
 serde_json = "*"
+```
+
+Simple example usage:
+```rust
+use std::{collections::HashMap, env};
+use mbta_rs::Client;
+
+let client = match env::var("MBTA_TOKEN") {
+    Ok(token) => Client::with_key(token),
+    Err(_) => Client::without_key()
+};
+
+let query_params = HashMap::from([
+    ("page[limit]".to_string(), "3".to_string())
+]);
+
+let alerts_response = client.alerts(query_params);
+if let Ok(response) = alerts_response {
+    for alert in response.data {
+        println!("MBTA alert: {}", alert.attributes.header);
+    }
+}
 ```
 
 <!-- CONTRIBUTE -->

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
 max_width = 140
 chain_width = 100
 fn_call_width = 100
+format_strings = false
+reorder_imports = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
 max_width = 140
 chain_width = 100
 fn_call_width = 100
-format_strings = false
 reorder_imports = true

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,16 +27,16 @@ macro_rules! mbta_endpoint_multiple {
             /// # Arguments
             ///
             /// * `query_params` - a [HashMap] of query parameter names to values
-            /// 
+            ///
             /// ```no_run
             /// # use std::{collections::HashMap, env};
             /// # use mbta_rs::Client;
-            /// # 
+            /// #
             /// # let client = match env::var("MBTA_TOKEN") {
             /// #     Ok(token) => Client::with_key(token),
             /// #     Err(_) => Client::without_key()
             /// # };
-            /// # 
+            /// #
             /// # let query_params = HashMap::from([
             /// #     ("page[limit]".to_string(), "3".to_string())
             /// # ]);
@@ -76,12 +76,12 @@ macro_rules! mbta_endpoint_single {
             /// ```no_run
             /// # use std::{collections::HashMap, env};
             /// # use mbta_rs::Client;
-            /// # 
+            /// #
             /// # let client = match env::var("MBTA_TOKEN") {
             /// #     Ok(token) => Client::with_key(token),
             /// #     Err(_) => Client::without_key()
             /// # };
-            /// # 
+            /// #
             /// # let id = "";
             #[doc = concat!("let ", stringify!($func), "_response = client.", stringify!($func), "(id);\n")]
             #[doc = concat!("if let Ok(item) = ", stringify!($func), "_response {\n")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,63 +1,106 @@
-//! Possible client errors that can occur when interacting with the API. Note that this is different from an error response.
+//! Possible client errors that can occur when interacting with the API.
 
-use std::{error::Error, fmt::Display, io::Error as IOError};
+use std::{
+    collections::HashMap,
+    error::Error as StdError,
+    fmt::{Display, Formatter, Result},
+    io::Error as IOError,
+};
 
-use serde_json::Error as JSONError;
-use ureq::Error as RequestError;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use ureq::{Error as RequestError, Transport};
+
+use super::APIVersion;
 
 /// All possible errors that can occur when using the client.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ClientError {
     /// I/O Error.
-    IOError(Box<IOError>),
-    /// HTTP request error.
-    RequestError(Box<RequestError>),
+    #[error("some kind of I/O error occured: `{0}`")]
+    IOError(#[from] IOError),
+    /// HTTP response error.
+    #[error("HTTP response error: `{errors:?}`")]
+    ResponseError {
+        /// Response errors.
+        errors: APIErrorResponse,
+    },
+    /// HTTP transport error.
+    #[error("HTTP transport error: `{0}`")]
+    TransportError(#[from] Transport),
     /// Invalid query parameter error.
-    InvalidQueryParam(String, String),
-    /// JSON parsing error.
-    JSONError(Box<JSONError>),
+    #[error("invalid query parameter: `{name}={value}`")]
+    InvalidQueryParam {
+        /// The name of the query parameter.
+        name: String,
+        /// The value of the query parameter.
+        value: String,
+    },
 }
 
-impl Display for ClientError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MBTA Client Error, ")?;
-        match self {
-            ClientError::IOError(i) => {
-                write!(f, "IO error: ")?;
-                i.fmt(f)
-            }
-            ClientError::RequestError(r) => {
-                write!(f, "request error: ")?;
-                r.fmt(f)
-            }
-            ClientError::InvalidQueryParam(k, v) => {
-                write!(f, "query parameter error: {}={}", k, v)
-            }
-            ClientError::JSONError(j) => {
-                write!(f, "JSON error: ")?;
-                j.fmt(f)
-            }
+/// Custom error response from the MBTA API.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct APIErrorResponse {
+    /// API errors.
+    pub errors: Vec<APIError>,
+    /// API version.
+    pub jsonapi: APIVersion,
+}
+
+impl Display for APIErrorResponse {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{{ errors: (")?;
+        for error in &self.errors {
+            write!(f, "{}, ", error)?;
         }
+        write!(f, "), api version: {:?}}}", self.jsonapi)
     }
 }
 
-impl Error for ClientError {}
+impl StdError for APIErrorResponse {}
 
-impl From<IOError> for ClientError {
-    fn from(error: IOError) -> Self {
-        ClientError::IOError(Box::new(error))
+/// Custom error from the MBTA API.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct APIError {
+    /// Error code.
+    pub code: String,
+    /// Error status.
+    pub status: String,
+    /// Error details.
+    #[serde(default)]
+    pub detail: Option<String>,
+    /// Error source.
+    #[serde(default)]
+    pub source: Option<HashMap<String, String>>,
+}
+
+impl Display for APIError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{{code: {}, status: {}", self.code, self.status)?;
+        if let Some(detail) = &self.detail {
+            write!(f, ", detail: {}", detail)?;
+        }
+        if let Some(source) = &self.source {
+            write!(f, ", source: {:?}", source)?;
+        }
+        write!(f, "}}")
     }
 }
+
+impl StdError for APIError {}
 
 impl From<RequestError> for ClientError {
     fn from(error: RequestError) -> Self {
-        ClientError::RequestError(Box::new(error))
-    }
-}
-
-impl From<JSONError> for ClientError {
-    fn from(error: JSONError) -> Self {
-        ClientError::JSONError(Box::new(error))
+        match error {
+            RequestError::Status(_, response) => {
+                let errs = response.into_json::<APIErrorResponse>();
+                match errs {
+                    Ok(errors) => Self::ResponseError { errors },
+                    Err(io) => Self::from(io),
+                }
+            }
+            RequestError::Transport(err) => Self::from(err),
+        }
     }
 }
 
@@ -66,7 +109,6 @@ mod tests {
     use super::*;
 
     use rstest::*;
-    use serde_json::{from_str, Value};
     use std::io::ErrorKind;
     use ureq::Response;
 
@@ -74,7 +116,7 @@ mod tests {
     fn test_client_error_display_io_error() {
         // Arrange
         let input = IOError::new(ErrorKind::BrokenPipe, "test error");
-        let expected = format!("MBTA Client Error, IO error: {}", input);
+        let expected = format!("some kind of I/O error occured: `{}`", input);
         let error = ClientError::from(input);
 
         // Act
@@ -85,10 +127,17 @@ mod tests {
     }
 
     #[rstest]
-    fn test_client_error_display_request_error() {
+    #[case::valid_error_text(
+        "{\"errors\": [{\"status\": \"403\", \"code\": \"forbidden\"}], \"jsonapi\": {\"version\": \"1.0\"}}",
+        "HTTP response error: `APIErrorResponse { errors: [APIError { code: \"forbidden\", status: \"403\", detail: None, source: None }], jsonapi: APIVersion { version: \"1.0\" } }`",
+    )]
+    #[case::invalid_error_text(
+        "foobar",
+        "some kind of I/O error occured: `Failed to read JSON: expected ident at line 1 column 2`"
+    )]
+    fn test_client_error_display_request_error(#[case] text: &str, #[case] expected: &str) {
         // Arrange
-        let input = RequestError::Status(404, Response::new(404, "Page not found", "foobar").unwrap());
-        let expected = format!("MBTA Client Error, request error: {}", input);
+        let input = RequestError::Status(404, Response::new(404, "Page not found", text).unwrap());
         let error = ClientError::from(input);
 
         // Act
@@ -101,22 +150,11 @@ mod tests {
     #[rstest]
     fn test_client_error_display_invalid_query_param_error() {
         // Arrange
-        let error = ClientError::InvalidQueryParam("foo".into(), "bar".into());
-        let expected = format!("MBTA Client Error, query parameter error: foo=bar");
-
-        // Act
-        let actual = format!("{}", error);
-
-        // Assert
-        assert_eq!(actual, expected);
-    }
-
-    #[rstest]
-    fn test_client_error_display_json_error() {
-        // Arrange
-        let input = from_str::<Value>("\"ee").unwrap_err();
-        let expected = format!("MBTA Client Error, JSON error: {}", input);
-        let error = ClientError::from(input);
+        let error = ClientError::InvalidQueryParam {
+            name: "foo".into(),
+            value: "bar".into(),
+        };
+        let expected = format!("invalid query parameter: `foo=bar`");
 
         // Act
         let actual = format!("{}", error);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 #![deny(
     missing_docs,
-    missing_debug_implementations, 
+    missing_debug_implementations,
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,
     unstable_features,
-    unused_import_braces, 
+    unused_import_braces,
     unused_qualifications
 )]
 #![doc(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,14 @@
-#![deny(missing_docs)]
+#![deny(
+    missing_docs,
+    missing_debug_implementations, 
+    missing_copy_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unstable_features,
+    unused_import_braces, 
+    unused_qualifications
+)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/bobertoyin/bobertoyin/main/mbta-rs-logo.png",
     html_favicon_url = "https://raw.githubusercontent.com/bobertoyin/bobertoyin/main/mbta-rs-logo.png"
@@ -6,7 +16,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod client;
-pub use client::{Client, BASE_URL};
+pub use client::*;
 pub mod error;
 pub use error::*;
 pub mod models;

--- a/src/models/alert.rs
+++ b/src/models/alert.rs
@@ -50,7 +50,7 @@ pub struct AlertAttributes {
 }
 
 /// Start and end dates for an active alert.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Clone, Copy)]
 pub struct ActivePeriod {
     /// Start date for an active alert.
     #[serde(with = "mbta_datetime_format")]

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -9,7 +9,6 @@ macro_rules! test_endpoint_plural_and_singular {
             use std::collections::HashMap;
 
             use rstest::*;
-            use ureq::Error;
 
             use mbta_rs::*;
 
@@ -47,15 +46,8 @@ macro_rules! test_endpoint_plural_and_singular {
                     .expect_err(&format!("{} did not fail", stringify!($plural_func)));
 
                 // Assert
-                if let ClientError::RequestError(e) = error {
-                    if let Error::Status(code, response) = *e {
-                        assert_eq!(code, 400);
-                        assert_eq!(response.status(), 400);
-                        assert_eq!(response.status_text(), "Bad Request");
-                        assert_eq!(response.get_url(), format!("https://api-v3.mbta.com/{}?sort=foobar", stringify!($plural_func)));
-                    } else {
-                        panic!("wrong request error type");
-                    }
+                if let ClientError::ResponseError { errors } = error {
+                    assert_eq!(errors.errors.len(), 1);
                 } else {
                     panic!("wrong error type");
                 }
@@ -71,9 +63,9 @@ macro_rules! test_endpoint_plural_and_singular {
                     .expect_err(&format!("{} did not fail", stringify!($plural_func)));
 
                 // Assert
-                if let ClientError::InvalidQueryParam(k, v) = error {
-                    assert_eq!(k, "foo");
-                    assert_eq!(v, "bar");
+                if let ClientError::InvalidQueryParam { name, value } = error {
+                    assert_eq!(name, "foo");
+                    assert_eq!(value, "bar");
                 } else {
                     panic!("wrong error type");
                 }
@@ -105,15 +97,8 @@ macro_rules! test_endpoint_plural_and_singular {
                 let error = client.$singular_func("foobar").expect_err("facility did not fail");
 
                 // Assert
-                if let ClientError::RequestError(e) = error {
-                    if let Error::Status(code, response) = *e {
-                        assert_eq!(code, 404);
-                        assert_eq!(response.status(), 404);
-                        assert_eq!(response.status_text(), "Not Found");
-                        assert_eq!(response.get_url(), format!("https://api-v3.mbta.com/{}/foobar", stringify!($plural_func)));
-                    } else {
-                        panic!("wrong request error type");
-                    }
+                if let ClientError::ResponseError { errors } = error {
+                    assert_eq!(errors.errors.len(), 1);
                 } else {
                     panic!("wrong error type");
                 }

--- a/tests/with_route.rs
+++ b/tests/with_route.rs
@@ -10,7 +10,6 @@ macro_rules! test_endpoint_plural_with_route {
             use std::collections::HashMap;
 
             use rstest::*;
-            use ureq::Error;
 
             use mbta_rs::*;
 
@@ -52,15 +51,8 @@ macro_rules! test_endpoint_plural_with_route {
                     .expect_err(&format!("{} did not fail", stringify!($plural_func)));
 
                 // Assert
-                if let ClientError::RequestError(e) = error {
-                    if let Error::Status(code, response) = *e {
-                        assert_eq!(code, 400);
-                        assert_eq!(response.status(), 400);
-                        assert_eq!(response.status_text(), "Bad Request");
-                        assert_eq!(response.get_url(), format!("https://api-v3.mbta.com/{}?sort=foobar", stringify!($plural_func)));
-                    } else {
-                        panic!("wrong request error type");
-                    }
+                if let ClientError::ResponseError { errors } = error {
+                    assert_eq!(errors.errors.len(), 1);
                 } else {
                     panic!("wrong error type");
                 }
@@ -76,9 +68,9 @@ macro_rules! test_endpoint_plural_with_route {
                     .expect_err(&format!("{} did not fail", stringify!($plural_func)));
 
                 // Assert
-                if let ClientError::InvalidQueryParam(k, v) = error {
-                    assert_eq!(k, "foo");
-                    assert_eq!(v, "bar");
+                if let ClientError::InvalidQueryParam { name, value } = error {
+                    assert_eq!(name, "foo");
+                    assert_eq!(value, "bar");
                 } else {
                     panic!("wrong error type");
                 }
@@ -97,7 +89,6 @@ macro_rules! test_endpoint_singular_with_route {
             use std::collections::HashMap;
 
             use rstest::*;
-            use ureq::Error;
 
             use mbta_rs::*;
 
@@ -140,15 +131,8 @@ macro_rules! test_endpoint_singular_with_route {
                 let error = client.$singular_func("foobar").expect_err(&format!("{} did not fail", stringify!($singular_func)));
 
                 // Assert
-                if let ClientError::RequestError(e) = error {
-                    if let Error::Status(code, response) = *e {
-                        assert_eq!(code, 404);
-                        assert_eq!(response.status(), 404);
-                        assert_eq!(response.status_text(), "Not Found");
-                        assert_eq!(response.get_url(), format!("https://api-v3.mbta.com/{}/foobar", stringify!($plural_func)));
-                    } else {
-                        panic!("wrong request error type");
-                    }
+                if let ClientError::ResponseError { errors } = error {
+                    assert_eq!(errors.errors.len(), 1);
                 } else {
                     panic!("wrong error type");
                 }


### PR DESCRIPTION
BREAKING CHANGE: adds new `ClientError` variants and removes the old `RequestError` variant