### PR TITLE
feat: removing endpoint macros from public API

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -43,9 +43,7 @@ See the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) s
 
 # Versioning
 
-See [SemVer specification](https://semver.org/) for the general idea behind semantic versioning, but versioning for this project will deviant from the SemVer specification somewhat to better match Rust library conventions.
-
-`PATCH` versioning will remain the same, being bumped whenever a bug fix is introduced. However, while this library is in `0.x.x`, `MINOR` version bumps *can* include breaking changes. This is because `0.x.x` releases are generally unstable in their APIs and signals to Rustaceans that the library still needs time to mature. However, once either `1.0.0` is released or some `0.x.x` release is deemed stable enough, breaking changes beyond that point warrant a `MAJOR` version bump, while backwards-compatible feature addition use the `MINOR` version bump instead.
+See [Cargo's SemVer compatability](https://doc.rust-lang.org/cargo/reference/semver.html) for how semantic versioning should be implemented within the context of the Rust ecosystem.
 
 ### Releasing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbta-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Robert Yin <bobertoyin@gmail.com>"]
 description = "Simple Rust client for interacting with the MBTA V3 API."

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,6 +10,7 @@ use super::*;
 pub const BASE_URL: &str = "https://api-v3.mbta.com";
 
 /// Attribute macro for quickly implementing MBTA client endpoints with multiple return objects.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! mbta_endpoint_multiple {
     (model=$model:ident, func=$func:ident, allowed_query_params=$allowed_query_params:expr) => {
@@ -28,7 +29,7 @@ macro_rules! mbta_endpoint_multiple {
             ///
             /// * `query_params` - a [HashMap] of query parameter names to values
             ///
-            /// ```no_run
+            /// ```
             /// # use std::{collections::HashMap, env};
             /// # use mbta_rs::Client;
             /// #
@@ -64,6 +65,7 @@ macro_rules! mbta_endpoint_multiple {
 }
 
 /// Attribute macro for quickly implementing MBTA client endpoints with single return objects.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! mbta_endpoint_single {
     (model=$model:ident, func=$func:ident, endpoint=$endpoint:expr, allowed_query_params=$allowed_query_params:expr) => {
@@ -73,7 +75,7 @@ macro_rules! mbta_endpoint_single {
             /// # Arguments
             #[doc = concat!("* `id` - the id of the ", stringify!($func), " to return")]
             ///
-            /// ```no_run
+            /// ```
             /// # use std::{collections::HashMap, env};
             /// # use mbta_rs::Client;
             /// #


### PR DESCRIPTION
BREAKING CHANGE: the endpoint macros for the client will no longer be accessible; this is how it should've been in the first place