### PR TITLE
feat: changing query params to slice of key-value pairs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mbta-rs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Robert Yin <bobertoyin@gmail.com>"]
 description = "Simple Rust client for interacting with the MBTA V3 API."

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ serde_json = "*"
 
 Simple example usage:
 ```rust
-use std::{collections::HashMap, env};
+use std::env;
 use mbta_rs::Client;
 
 let client = match env::var("MBTA_TOKEN") {
@@ -63,11 +63,11 @@ let client = match env::var("MBTA_TOKEN") {
     Err(_) => Client::without_key()
 };
 
-let query_params = HashMap::from([
-    ("page[limit]".to_string(), "3".to_string())
-]);
+let query_params = [
+    ("page[limit]", "3")
+];
 
-let alerts_response = client.alerts(query_params);
+let alerts_response = client.alerts(&query_params);
 if let Ok(response) = alerts_response {
     for alert in response.data {
         println!("MBTA alert: {}", alert.attributes.header);
@@ -99,7 +99,7 @@ let client = match env::var("MBTA_TOKEN") {
     Err(_) => Client::without_key()
 };
 
-let routes = client.routes(HashMap::from([("filter[type]".into(), "0,1".into())])).expect("failed to get routes");
+let routes = client.routes(&[("filter[type]", "0,1")]).expect("failed to get routes");
 let mut map = StaticMapBuilder::new()
     .width(1000)
     .height(1000)
@@ -110,9 +110,9 @@ let mut map = StaticMapBuilder::new()
     .expect("failed to build map");
 
 for route in routes.data {
-    let query = HashMap::from([("filter[route]".into(), route.id)]);
+    let query_params = [("filter[route]", &route.id)];
     let shapes = client
-        .shapes(query.clone())
+        .shapes(&query_params)
         .expect("failed to get shapes");
     for shape in shapes.data {
         shape
@@ -120,7 +120,7 @@ for route in routes.data {
             .expect("failed to plot shape");
     }
     let stops = client
-        .stops(query.clone())
+        .stops(&query_params)
         .expect("failed to get stops");
     for stop in stops.data {
         stop.plot(

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -1,6 +1,6 @@
 //! Simple tests for tile map plotting.
 
-use std::{collections::HashMap, fs::remove_file, path::PathBuf};
+use std::{fs::remove_file, path::PathBuf};
 
 use mbta_rs::{map::*, *};
 use raster::{compare::similar, open};
@@ -24,7 +24,8 @@ fn image_file(relative_path: &str) -> PathBuf {
 #[rstest]
 fn test_simple_map_render(client: Client) {
     // Arrange
-    let routes = client.routes(HashMap::from([("filter[type]".into(), "0,1".into())])).expect("failed to get routes");
+    let route_params = [("filter[type]", "0,1")];
+    let routes = client.routes(&route_params).expect("failed to get routes");
     let mut map = StaticMapBuilder::new()
         .width(1000)
         .height(1000)
@@ -40,19 +41,19 @@ fn test_simple_map_render(client: Client) {
 
     // Act
     for route in routes.data {
-        let query = HashMap::from([("filter[route]".into(), route.id)]);
-        let shapes = client.shapes(query.clone()).expect("failed to get shapes");
+        let params = [("filter[route]", &route.id)];
+        let shapes = client.shapes(&params).expect("failed to get shapes");
         for shape in shapes.data {
             shape
                 .plot(&mut map, true, PlotStyle::new((route.attributes.color.clone(), 3.0), Some(("#FFFFFF".into(), 1.0))))
                 .expect("failed to plot shape");
         }
-        let stops = client.stops(query.clone()).expect("failed to get stops");
+        let stops = client.stops(&params).expect("failed to get stops");
         for stop in stops.data {
             stop.plot(&mut map, true, PlotStyle::new((route.attributes.color.clone(), 3.0), Some(("#FFFFFF".into(), 1.0))))
                 .expect("failed to plot stop");
         }
-        let vehicles = client.vehicles(query).expect("failed to get vehicles");
+        let vehicles = client.vehicles(&params).expect("failed to get vehicles");
         for vehicle in vehicles.data {
             vehicle
                 .plot(&mut map, true, IconStyle::new(image_file("train.png"), 12.5, 12.5))

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -6,8 +6,6 @@ macro_rules! test_endpoint_plural_and_singular {
     (plural_func=$plural_func:ident, singular_func=$singular_func:ident) => {
         #[cfg(test)]
         mod $plural_func {
-            use std::collections::HashMap;
-
             use rstest::*;
 
             use mbta_rs::*;
@@ -24,11 +22,10 @@ macro_rules! test_endpoint_plural_and_singular {
             #[rstest]
             fn success_plural_models(client: Client) {
                 // Arrange
+                let params = [("page[limit]", "3")];
 
                 // Act
-                let $plural_func = client
-                    .$plural_func(HashMap::from([("page[limit]".into(), "3".into())]))
-                    .expect(&format!("failed to get {}", stringify!($plural_func)));
+                let $plural_func = client.$plural_func(&params).expect(&format!("failed to get {}", stringify!($plural_func)));
 
                 // Assert
                 assert_eq!($plural_func.data.len(), 3);
@@ -39,11 +36,10 @@ macro_rules! test_endpoint_plural_and_singular {
             #[rstest]
             fn request_failure_plural_models(client: Client) {
                 // Arrange
+                let params = [("sort", "foobar")];
 
                 // Act
-                let error = client
-                    .$plural_func(HashMap::from([("sort".into(), "foobar".into())]))
-                    .expect_err(&format!("{} did not fail", stringify!($plural_func)));
+                let error = client.$plural_func(&params).expect_err(&format!("{} did not fail", stringify!($plural_func)));
 
                 // Assert
                 if let ClientError::ResponseError { errors } = error {
@@ -56,11 +52,10 @@ macro_rules! test_endpoint_plural_and_singular {
             #[rstest]
             fn query_param_failure_plural_models(client: Client) {
                 // Arrange
+                let params = [("foo", "bar")];
 
                 // Act
-                let error = client
-                    .$plural_func(HashMap::from([("foo".into(), "bar".into())]))
-                    .expect_err(&format!("{} did not fail", stringify!($plural_func)));
+                let error = client.$plural_func(&params).expect_err(&format!("{} did not fail", stringify!($plural_func)));
 
                 // Assert
                 if let ClientError::InvalidQueryParam { name, value } = error {
@@ -74,9 +69,8 @@ macro_rules! test_endpoint_plural_and_singular {
             #[rstest]
             fn success_singular_model(client: Client) {
                 // Arrange
-                let $plural_func = client
-                    .$plural_func(HashMap::from([("page[limit]".into(), "3".into())]))
-                    .expect(&format!("failed to get {}", stringify!($plural_func)));
+                let params = [("page[limit]", "3")];
+                let $plural_func = client.$plural_func(&params).expect(&format!("failed to get {}", stringify!($plural_func)));
 
                 // Act & Assert
                 for $singular_func in $plural_func.data {


### PR DESCRIPTION
BREAKING: removes support for using `HashMap`s as query parameters